### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix for [https://github.com/nicholaswmin/generic-repo/security/code-scanning/1](https://github.com/nicholaswmin/generic-repo/security/code-scanning/1)

- `contents: read`

This preserves current functionality for checkout and test execution while preventing unintended write access if repo/org defaults are permissive or later changed. 
